### PR TITLE
Don't relay command line arguments to Gtk::Application::create

### DIFF
--- a/dictation.hpp
+++ b/dictation.hpp
@@ -92,7 +92,7 @@ class Dictation {
 	void getFilename(char **dest) const;
 
 	/*
-	 * I could modify AudioFileReader to allow for chunkSize, historySize, and preloadSize
+	 * I could modify AudioFileReader to allow for latency, historySize, and preloadSize
 	 * to be changed without restarting the dictation, but this function is only called
 	 * when the user closes the options window, so I'll take the easy route and just close
 	 * and re-open the file

--- a/main.cpp
+++ b/main.cpp
@@ -37,7 +37,7 @@
 #include "changelog.hpp"
 
 int main(int argc, char *argv[]) {
-	Glib::RefPtr<Gtk::Application> program = Gtk::Application::create(argc, argv, "gtk.OpenScribe", Gio::APPLICATION_HANDLES_OPEN);
+	Glib::RefPtr<Gtk::Application> program = Gtk::Application::create("gtk.OpenScribe", Gio::APPLICATION_HANDLES_OPEN);
 
 	Version lastUsed = getLastVersionUsed();
 	if (lastUsed == Version(0) && QTranscribeInstalled()) {
@@ -83,10 +83,7 @@ int main(int argc, char *argv[]) {
 	ChangelogWindow changelog(lastUsed);
 	if (lastUsed != CURRENT_VERSION && lastUsed != Version(0)) {
 		changelog.show();
-		int fake_argc = 1;
-		char *temp = argv[0];
-		char **fake_argv = &temp;
-		Gtk::Application::create(fake_argc, fake_argv, "gtk.OpenScribe", Gio::APPLICATION_HANDLES_OPEN)->run(changelog);
+		Gtk::Application::create("gtk.OpenScribe", Gio::APPLICATION_HANDLES_OPEN)->run(changelog);
 	}
 
 	if (FPC.start(	MainWindow::onPedalEventAdaptor, ConfigWindow::onDeviceConnectAdaptor,


### PR DESCRIPTION
Passing in invalid GTK arguments to Gtk::Application::create causes the application to freeze without printing errors for some reason.

fixes #1 
